### PR TITLE
remove css-loader from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "babel-plugin-transform-runtime": "^6.8.0",
     "babel-runtime": "^5.8.0",
     "babel-preset-es2015": "^6.6.0",
-    "css-loader": "*",
     "vue-html-loader": "^1.0.0",
     "vue-style-loader": "^1.0.0",
     "vue-hot-reload-api": "^1.2.0"


### PR DESCRIPTION
Since npm3+,it will not install peerDependencies automatically,when I execute `npm shrinkWrap --dev`,it shows the error:**peer invalid: css-loader@*, required by vue-loader@9.7.0**